### PR TITLE
add ListCommand to CommandFactory

### DIFF
--- a/src/main/java/internity/commands/CommandFactory.java
+++ b/src/main/java/internity/commands/CommandFactory.java
@@ -12,6 +12,8 @@ public class CommandFactory {
             return ArgumentParser.parseDeleteCommandArgs(args);
         case "update":
             return ArgumentParser.parseUpdateCommandArgs(args);
+        case "list":
+            return new ListCommand();
         case "exit":
             return new ExitCommand();
         default:


### PR DESCRIPTION
Add support for the "list" command in the command factory, allowing the application to recognize and handle the "list" command appropriately.

- Command handling:
  * Added a case for the "list" command in the `createCommand` method of `CommandFactory.java`, returning a new instance of `ListCommand`.

_Note by author: I forgot to add listCommand. Now 'list' command is usable in the app._

closes #53 